### PR TITLE
Field children props input

### DIFF
--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -120,20 +120,18 @@ var Field = function (_React$Component) {
       var inputProps = {
         name: this.props.name,
         value: this.state.value,
-        onChange: this.onChange
+        onChange: this.onChange,
+        type: this.props.type
       };
 
       if (!childCount) {
         return _react2.default.createElement(_Input2.default, _extends({}, this.props, inputProps));
-      } else if (childCount === 1) {
-        return _react2.default.cloneElement(this.props.children, inputProps);
       }
-
       return _react2.default.createElement(
         'label',
         { htmlFor: this.props.name },
         _react2.default.Children.map(this.props.children, function (child) {
-          return (0, _utilities.mapPropsToInput)(_react2.default, child, inputProps);
+          return (0, _utilities.mapPropsToChild)(child, 'input', inputProps);
         })
       );
     }
@@ -148,7 +146,8 @@ Field.propTypes = {
   onChange: _react2.default.PropTypes.func,
   debounce: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number]),
   match: _react2.default.PropTypes.string,
-  children: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.element, _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.element)])
+  children: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.element, _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.element)]),
+  type: _react2.default.PropTypes.string
 };
 
 Field.defaultProps = {
@@ -157,7 +156,8 @@ Field.defaultProps = {
   onChange: undefined,
   debounce: 0,
   match: undefined,
-  children: []
+  children: [],
+  type: 'text'
 };
 
 exports.default = Field;

--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -120,8 +120,6 @@ var Field = function (_React$Component) {
       var inputProps = {
         name: this.props.name,
         value: this.state.value,
-        valid: this.state.valid,
-        pristine: this.state.pristine,
         onChange: this.onChange
       };
 
@@ -131,20 +129,11 @@ var Field = function (_React$Component) {
         return _react2.default.cloneElement(this.props.children, inputProps);
       }
 
-      if (!_react2.default.Children.toArray(this.props.children).find(function (child) {
-        return child.type.name === 'Input';
-      })) {
-        throw new Error('No `Input` component provided to `Field`.');
-      }
-
       return _react2.default.createElement(
         'label',
         { htmlFor: this.props.name },
         _react2.default.Children.map(this.props.children, function (child) {
-          if (child.type.name === 'Input') {
-            return _react2.default.cloneElement(child, inputProps);
-          }
-          return child;
+          return (0, _utilities.mapPropsToInput)(_react2.default, child, inputProps);
         })
       );
     }

--- a/dist/components/Form.js
+++ b/dist/components/Form.js
@@ -53,14 +53,12 @@ var Form = function (_React$Component) {
       return _react2.default.createElement(
         'form',
         { onSubmit: this.onSubmit },
-        _react2.default.Children.count(this.props.children) && _react2.default.Children.map(this.props.children, function (child) {
-          if (child.type.name === 'Field') {
-            var name = child.props.name;
+        _react2.default.Children.map(this.props.children, function (child) {
+          var name = child.props.name;
 
-            var value = _this2.state[name].value;
-            return _react2.default.cloneElement(child, { key: child.props.name, value: value, name: name });
-          }
-          return _react2.default.cloneElement(child);
+          var value = _this2.state[name].value;
+          var fieldProps = { key: child.props.name, value: value, name: name };
+          return (0, _utilities.mapPropsToChild)(child, 'Field', fieldProps);
         })
       );
     }

--- a/dist/helpers/utilities.js
+++ b/dist/helpers/utilities.js
@@ -11,6 +11,7 @@ exports.updateValidators = updateValidators;
 exports.isValid = isValid;
 exports.addFieldToState = addFieldToState;
 exports.getValuesOf = getValuesOf;
+exports.mapPropsToInput = mapPropsToInput;
 
 var _validators = require('./validators');
 
@@ -103,4 +104,16 @@ function getValuesOf() {
   return Object.keys(obj).map(function (key) {
     return obj[key];
   });
+}
+
+function mapPropsToInput(React, child, props) {
+  if (child.type === 'input') {
+    return React.cloneElement(child, props);
+  } else if (child.props && child.props.children) {
+    var newChildren = React.Children.map(child.props.children, function (nestedChild) {
+      return mapPropsToInput(React, nestedChild, props);
+    });
+    return React.cloneElement(child, { children: newChildren });
+  }
+  return child;
 }

--- a/dist/helpers/utilities.js
+++ b/dist/helpers/utilities.js
@@ -11,13 +11,19 @@ exports.updateValidators = updateValidators;
 exports.isValid = isValid;
 exports.addFieldToState = addFieldToState;
 exports.getValuesOf = getValuesOf;
-exports.mapPropsToInput = mapPropsToInput;
+exports.mapPropsToChild = mapPropsToChild;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
 
 var _validators = require('./validators');
 
 var validatorFunctions = _interopRequireWildcard(_validators);
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function assembleValidators(_ref) {
   var email = _ref.email,
@@ -106,14 +112,14 @@ function getValuesOf() {
   });
 }
 
-function mapPropsToInput(React, child, props) {
-  if (child.type === 'input') {
-    return React.cloneElement(child, props);
+function mapPropsToChild(child, type, props) {
+  if (child.type === type || child.type.name === type) {
+    return _react2.default.cloneElement(child, props);
   } else if (child.props && child.props.children) {
-    var newChildren = React.Children.map(child.props.children, function (nestedChild) {
-      return mapPropsToInput(React, nestedChild, props);
+    var newChildren = _react2.default.Children.map(child.props.children, function (nestedChild) {
+      return mapPropsToChild(_react2.default, nestedChild, props);
     });
-    return React.cloneElement(child, { children: newChildren });
+    return _react2.default.cloneElement(child, { children: newChildren });
   }
   return child;
 }

--- a/dist/helpers/utilities.js
+++ b/dist/helpers/utilities.js
@@ -113,13 +113,13 @@ function getValuesOf() {
 }
 
 function mapPropsToChild(child, type, props) {
-  if (child.type === type || child.type.name === type) {
+  if (child.type === type || typeof child.type === 'function' && child.type.name === type) {
     return _react2.default.cloneElement(child, props);
   } else if (child.props && child.props.children) {
     var newChildren = _react2.default.Children.map(child.props.children, function (nestedChild) {
-      return mapPropsToChild(_react2.default, nestedChild, props);
+      return mapPropsToChild(nestedChild, type, props);
     });
-    return _react2.default.cloneElement(child, { children: newChildren });
+    return _react2.default.cloneElement(child, null, newChildren);
   }
   return child;
 }

--- a/readme.md
+++ b/readme.md
@@ -34,18 +34,16 @@ Formwizard-react can be used to both quickly compose forms or add validation to 
     return (
       <Form fields={['name_field', 'email_field', 'age_field']}>
         <Field name="name_field" length={[3, 24]} />
-        <Field name="email_field" required email debounce="300" />
         <Field name="age_field" required min="18" max="150">
-          <Input>
-            <AgePickerComponent />
-          </Input>
+          <AgePickerComponent />
         </Field>
-
+        <Field name="email_field" required email debounce="300">
+          <label>
+            Email: <input />
+          </label>
+          <span>Email Address must use a '.edu' domain!</span>
+        </Field>
         <CustomSubmitButton />
-
-        <Data>
-          <SummarizeFormComponent />
-        </Data>
       </Form>
      );
   } 
@@ -76,12 +74,15 @@ Formwizard-react can be used to both quickly compose forms or add validation to 
         <form>
           <div>
             <input type="text" name="name" onChange={this.onChange}/>  
-            // Fields are controlled! You must pass `value` and `onChange` if you aren't using `Form`
-            <Field name="age" value={this.state.age} onChange={this.onChange} min="18" max="150">
-              <Input>
-                <input type="text" name="name" onChange={this.onChange}/>
-              </Input>
+            
+            <Field name="email" type="email" value={this.state.age} onChange={this.onChange} length={[6, 16]} email>
+              <label>
+                // The input is controlled! `Field` passes `name`, `value`, `type`, and `onChange` props for you!
+                Enter Email: <input />
+              </label>
+              <span>Email Address must use a '.edu' domain!</span>
             </Field>
+            
           </div>
           <button type="submit" />
         </form>
@@ -94,7 +95,7 @@ Formwizard-react can be used to both quickly compose forms or add validation to 
 ### Form  
 The `Form` component is a stateful higher-order-component which wraps presentational form components consisting of arbitrary input fields. Simply import the `Form` component and nest your custom components inside the `Form` tag.  
 
-The `Form` component will behave as follows with respect to its *direct* children:  
+The `Form` component will behave as follows with respect to its children:  
 
   1. Any `Field` tag will be passed the state associated with the `Field`'s name (`Form.state[child.props.name]`).  
   2. Any other component or element will be rendered with the props it would otherwise be passed.
@@ -104,15 +105,16 @@ The `Form` component should be passed an `onSubmit` handler if you want to inter
 ### Field  
 The `Field` component is a stateful, higher-order component which wraps a given presentational input component (or creates a default one). Input elements should be nested inside of `Field` tag. Each `Field` component will maintain its child's input element's value (`state.value` {String, Number}), validity(`state.valid`{Boolean}), and pristine state (`state.pristine` {Boolean}), as well as provide an onChange handler passed down through `props.onChange`.  
 
-The `Field` component will behave as follows with respect to its *direct* children:  
+The `Field` component will behave as follows with respect to its children:  
   
-  1. Any `Input` tag will be passed the current field state (`value`, `valid`, `pristine`). If multiple `Input` tags are passed to `Field`, they would all share a single state (not recommended).  
-  2. If no components are nested in a `Field` component, the default `Input` component will be used.  
-  3. If only a single direct child is passed to `Field`, it will be passed all of the `Field`'s props.  
+  1. If no components are nested in a `Field` component, a default label and input element will be used.  
+  2. Any `input` tag will be passed `name`, `type`, `value`, and `onChange` props.  
+  3. If only a single direct child is passed to `Field`, it will be passed all of the relevant input props.  
+  4. If multiple `input` tags are nested in a single `Field`, they would all share a single state (not recommended).  
   
-*Note:* Only one input element should be nested inside of a `Field` tag (see #1 above).
+*Note:* Only one input element should be nested inside of a `Field` tag (see #4 above).
 
-There are also a handful of different validators and properties (debounce, length, etc.) that can be attached to the field component. This is done through declaring props passed to the field component. See below for the list of validators.  
+There are also a handful of different validators and properties (debounce, length, etc.) that can be attached to the field component. This is done by declaring props on the `Field` component. See below for the list of validators.  
 
 #### props.value = value
 > @param {String} [value=''] - The value of the wrapped input component.   

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import debounce from 'lodash.debounce';
 import DefaultInput from './Input';
-import { assembleValidators, isValid, updateValidators, getValuesOf } from '../helpers/utilities';
+import {
+  assembleValidators,
+  isValid,
+  updateValidators,
+  getValuesOf,
+  mapPropsToInput,
+} from '../helpers/utilities';
 
 const Field = class extends React.Component {
   constructor(props) {
@@ -97,12 +103,8 @@ const Field = class extends React.Component {
 
     return (
       <label htmlFor={this.props.name}>
-        {React.Children.map(this.props.children, (child) => {
-          if (child.type.name === 'Input') {
-            return React.cloneElement(child, inputProps);
-          }
-          return child;
-        })}
+        {React.Children
+          .map(this.props.children, child => mapPropsToInput(React, child, inputProps))}
       </label>
     );
   }

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -86,8 +86,6 @@ const Field = class extends React.Component {
     const inputProps = {
       name: this.props.name,
       value: this.state.value,
-      valid: this.state.valid,
-      pristine: this.state.pristine,
       onChange: this.onChange,
     };
 
@@ -96,11 +94,6 @@ const Field = class extends React.Component {
     } else if (childCount === 1) {
       return React.cloneElement(this.props.children, inputProps);
     }
-
-    if (!React.Children.toArray(this.props.children).find(child => child.type.name === 'Input')) {
-      throw new Error('No `Input` component provided to `Field`.');
-    }
-
     return (
       <label htmlFor={this.props.name}>
         {React.Children

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -6,7 +6,7 @@ import {
   isValid,
   updateValidators,
   getValuesOf,
-  mapPropsToInput,
+  mapPropsToChild,
 } from '../helpers/utilities';
 
 const Field = class extends React.Component {
@@ -87,17 +87,16 @@ const Field = class extends React.Component {
       name: this.props.name,
       value: this.state.value,
       onChange: this.onChange,
+      type: this.props.type,
     };
 
     if (!childCount) {
       return <DefaultInput {...this.props} {...inputProps} />;
-    } else if (childCount === 1) {
-      return React.cloneElement(this.props.children, inputProps);
     }
     return (
       <label htmlFor={this.props.name}>
         {React.Children
-          .map(this.props.children, child => mapPropsToInput(React, child, inputProps))}
+          .map(this.props.children, child => mapPropsToChild(child, 'input', inputProps))}
       </label>
     );
   }
@@ -113,6 +112,7 @@ Field.propTypes = {
     React.PropTypes.element,
     React.PropTypes.arrayOf(React.PropTypes.element),
   ]),
+  type: React.PropTypes.string,
 };
 
 Field.defaultProps = {
@@ -122,6 +122,7 @@ Field.defaultProps = {
   debounce: 0,
   match: undefined,
   children: [],
+  type: 'text',
 };
 
 export default Field;

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { addFieldToState } from '../helpers/utilities';
+import { addFieldToState, mapPropsToChild } from '../helpers/utilities';
 
 const Form = class extends React.Component {
   constructor(props) {
@@ -22,14 +22,12 @@ const Form = class extends React.Component {
   render() {
     return (
       <form onSubmit={this.onSubmit}>
-        {React.Children.count(this.props.children) &&
-          React.Children.map(this.props.children, (child) => {
-            if (child.type.name === 'Field') {
-              const { name } = child.props;
-              const value = this.state[name].value;
-              return React.cloneElement(child, { key: child.props.name, value, name });
-            }
-            return React.cloneElement(child);
+        {React.Children
+          .map(this.props.children, (child) => {
+            const { name } = child.props;
+            const value = this.state[name].value;
+            const fieldProps = { key: child.props.name, value, name };
+            return mapPropsToChild(child, 'Field', fieldProps);
           })}
       </form>
     );

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -57,3 +57,14 @@ export function addFieldToState(field) {
 export function getValuesOf(obj = {}) {
   return Object.keys(obj).map(key => obj[key]);
 }
+
+export function mapPropsToInput(React, child, props) {
+  if (child.type === 'input') {
+    return React.cloneElement(child, props);
+  } else if (child.props.children) {
+    const newChildren = React.Children.map(child.props.children, nestedChild => (
+      mapPropsToInput(React, nestedChild, props)));
+    return React.cloneElement(child, { children: newChildren });
+  }
+  return child;
+}

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -61,7 +61,7 @@ export function getValuesOf(obj = {}) {
 export function mapPropsToInput(React, child, props) {
   if (child.type === 'input') {
     return React.cloneElement(child, props);
-  } else if (child.props.children) {
+  } else if (child.props && child.props.children) {
     const newChildren = React.Children.map(child.props.children, nestedChild => (
       mapPropsToInput(React, nestedChild, props)));
     return React.cloneElement(child, { children: newChildren });

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import * as validatorFunctions from './validators';
 
 export function assembleValidators({
@@ -58,12 +59,12 @@ export function getValuesOf(obj = {}) {
   return Object.keys(obj).map(key => obj[key]);
 }
 
-export function mapPropsToInput(React, child, props) {
-  if (child.type === 'input') {
+export function mapPropsToChild(child, type, props) {
+  if (child.type === type || child.type.name === type) {
     return React.cloneElement(child, props);
   } else if (child.props && child.props.children) {
     const newChildren = React.Children.map(child.props.children, nestedChild => (
-      mapPropsToInput(React, nestedChild, props)));
+      mapPropsToChild(React, nestedChild, props)));
     return React.cloneElement(child, { children: newChildren });
   }
   return child;

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -60,12 +60,12 @@ export function getValuesOf(obj = {}) {
 }
 
 export function mapPropsToChild(child, type, props) {
-  if (child.type === type || child.type.name === type) {
+  if (child.type === type || (typeof child.type === 'function' && child.type.name === type)) {
     return React.cloneElement(child, props);
   } else if (child.props && child.props.children) {
     const newChildren = React.Children.map(child.props.children, nestedChild => (
-      mapPropsToChild(React, nestedChild, props)));
-    return React.cloneElement(child, { children: newChildren });
+      mapPropsToChild(nestedChild, type, props)));
+    return React.cloneElement(child, null, newChildren);
   }
   return child;
 }

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -41,8 +41,6 @@ export function addFieldToState(field) {
 
   if (Array.isArray(field)) {
     field.forEach(name => this.addFieldToState(name));
-  } else if (typeof field === 'string') {
-    this.state[field] = { value: '', valid: false, pristine: false };
   } else if (typeof field === 'object') {
     const { name, value, valid, pristine } = field.props;
     const newState = { value: '', valid: false, pristine: false };

--- a/tests/components/Field.spec.js
+++ b/tests/components/Field.spec.js
@@ -41,9 +41,7 @@ describe('<Field /> Higher-Order-Component', () => {
       wrapper = mount(
         <Field value={'value!'} onChange={onChange}>
           <h4>My Test Input!</h4>
-          <Input>
-            {props => <input value={props.value} onChange={props.onChange} />}
-          </Input>
+          <input />
         </Field>);
     });
 
@@ -58,15 +56,13 @@ describe('<Field /> Higher-Order-Component', () => {
       expect(wrapper.find('h4')).to.have.length(1);
       expect(wrapper.find('h4').text()).to.equal('My Test Input!');
 
-      const renderedCustomInput = wrapper.find('Input');
+      const renderedCustomInput = wrapper.find('input');
       expect(renderedCustomInput).to.have.length(1);
 
       const renderedCustomInputProps = renderedCustomInput.props();
 
       expect(renderedCustomInputProps).to.have.property('value', renderedCustomInputProps.value);
       expect(renderedCustomInputProps).to.have.property('name', renderedCustomInputProps.name);
-      expect(renderedCustomInputProps).to.have.property('valid', renderedCustomInputProps.valid);
-      expect(renderedCustomInputProps).to.have.property('pristine', renderedCustomInputProps.pristine);
 
       expect(renderedCustomInputProps).to.have.property('onChange');
       expect(typeof renderedCustomInputProps.onChange).to.eql('function');


### PR DESCRIPTION
`Field` component no longer looks for an `Input` component, and instead will traverse its children to find the `input` element (if one is present). If it finds one, it will automatically pass `name`, `value`, and `onChange` props.